### PR TITLE
Remove unnecessary raise notice in patternProperties validation

### DIFF
--- a/postgres-json-schema--0.1.1.sql
+++ b/postgres-json-schema--0.1.1.sql
@@ -240,7 +240,6 @@ BEGIN
   IF schema ? 'patternProperties' AND jsonb_typeof(data) = 'object' THEN
     FOR prop IN SELECT jsonb_object_keys(data) LOOP
       FOR pattern IN SELECT jsonb_object_keys(schema->'patternProperties') LOOP
-        RAISE NOTICE 'prop %s, pattern %, schema %', prop, pattern, schema->'patternProperties'->pattern;
         IF prop ~ pattern AND NOT @extschema@.validate_json_schema(schema->'patternProperties'->pattern, data->prop, root_schema) THEN
           RETURN false;
         END IF;


### PR DESCRIPTION
This merge request removes a superfluous `RAISE NOTICE` statement that was cluttering the terminal output during the validation of pattern properties.

By removing this RAISE NOTICE, we can maintain cleaner logs without losing any critical information.