### PR TITLE
Provide partial support for string "format" constraint

### DIFF
--- a/postgres-json-schema--0.1.1.sql
+++ b/postgres-json-schema--0.1.1.sql
@@ -237,6 +237,35 @@ BEGIN
     END IF;
   END IF;
 
+  IF schema ? 'format' AND jsonb_typeof(data) = 'string' 
+                       AND schema->>'format' in ('date-time', 'date', 'time', 'duration', 'ipv4', 'ipv6', 'uuid') THEN
+    declare
+      str_format text := schema->>'format';
+      str_value text := data #>> '{}'; 
+      dynsql text;
+    begin
+	  dynsql := format(
+	  		'select %L::%s', 
+	  		str_value, 
+	  		case str_format
+	          when 'date-time' then 'timestamptz' 
+	          when 'duration' then 'interval'
+	          when 'ipv4' then 'inet'
+	          when 'ipv6' then 'inet'
+	          else str_format
+	        end
+	       );
+	  -- raise notice '%', dynsql;
+	  execute dynsql;
+	  if str_format in ('ipv4', 'ipv6') and (str_format = 'ipv6' and str_value !~ ':' or 
+	                                         str_format = 'ipv4' and str_value  ~ ':') then
+	     RETURN false;
+	  end if;  
+    exception when others then 
+      RETURN false;
+    end; 
+  END IF;
+
   IF schema ? 'patternProperties' AND jsonb_typeof(data) = 'object' THEN
     FOR prop IN SELECT jsonb_object_keys(data) LOOP
       FOR pattern IN SELECT jsonb_object_keys(schema->'patternProperties') LOOP

--- a/postgres-json-schema--0.1.1.sql
+++ b/postgres-json-schema--0.1.1.sql
@@ -240,6 +240,7 @@ BEGIN
   IF schema ? 'format' AND jsonb_typeof(data) = 'string' THEN
     DECLARE
       target text := (data #>> '{}');
+      EMAIL_RX constant text := '^[\w.!#$%&''*+/=?^`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)*$';
     BEGIN
       CASE (schema->>'format')
         WHEN 'date-time' THEN PERFORM target::timestamptz; 
@@ -250,6 +251,7 @@ BEGIN
         WHEN 'ipv6'      THEN PERFORM target::inet; IF target NOT LIKE '%:%' THEN RAISE; END IF;
         WHEN 'ipv4'      THEN PERFORM target::inet; IF target LIKE '%:%' THEN RAISE; END IF;
         WHEN 'regex'     THEN PERFORM '' ~ target; 
+        WHEN 'email'     THEN IF target !~* EMAIL_RX THEN RAISE; END IF;
         ELSE null; -- consistent with current behaviour - validate positive for unsupported options
       END CASE;
     EXCEPTION WHEN OTHERS THEN

--- a/postgres-json-schema--0.1.1.sql
+++ b/postgres-json-schema--0.1.1.sql
@@ -240,7 +240,7 @@ BEGIN
   IF schema ? 'format' AND jsonb_typeof(data) = 'string' THEN
     DECLARE
       target text := (data #>> '{}');
-      EMAIL_RX constant text := '^[\w.!#$%&''*+/=?^`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)*$';
+      EMAIL_RX constant text := '^[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$';
     BEGIN
       CASE (schema->>'format')
         WHEN 'date-time' THEN PERFORM target::timestamptz; 
@@ -251,7 +251,7 @@ BEGIN
         WHEN 'ipv6'      THEN PERFORM target::inet; IF target NOT LIKE '%:%' THEN RAISE; END IF;
         WHEN 'ipv4'      THEN PERFORM target::inet; IF target LIKE '%:%' THEN RAISE; END IF;
         WHEN 'regex'     THEN PERFORM '' ~ target; 
-        WHEN 'email'     THEN IF target !~* EMAIL_RX THEN RAISE; END IF;
+        WHEN 'email'     THEN IF target !~ EMAIL_RX THEN RAISE; END IF;
         ELSE null; -- consistent with current behaviour - validate positive for unsupported options
       END CASE;
     EXCEPTION WHEN OTHERS THEN

--- a/postgres-json-schema--0.1.1.sql
+++ b/postgres-json-schema--0.1.1.sql
@@ -250,7 +250,7 @@ BEGIN
         WHEN 'ipv6'      THEN PERFORM target::inet; IF target NOT LIKE '%:%' THEN RAISE; END IF;
         WHEN 'ipv4'      THEN PERFORM target::inet; IF target LIKE '%:%' THEN RAISE; END IF;
         WHEN 'regex'     THEN PERFORM '' ~ target; 
-        ELSE null;
+        ELSE null; -- consistent with current behaviour - validate positive for unsupported options
       END CASE;
     EXCEPTION WHEN OTHERS THEN
       RETURN false;


### PR DESCRIPTION
### Provide partial support for string ["format"](https://json-schema.org/understanding-json-schema/reference/string#format) constraint

Formats that correspond to native PostgreSQL data types are implemented. These are

> date-time, date, time, duration, uuid, ipv4, ipv6, regex  

Email format validation by a regex suggested by [pbaumard](https://github.com/pbaumard).

Consistent with current behaviour unsupported options validate positive.